### PR TITLE
Validate CSRF token before saving configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - RoundRobin Plugin
 
+## Unreleased
+
+### Security
+- Validate the GLPI CSRF token before saving RoundRobin configuration changes.
+
 ## [2.3.0] - 2026-06-25
 
 ### Highlights

--- a/front/config.form.php
+++ b/front/config.form.php
@@ -32,6 +32,7 @@ Html::header(
 
 if (isset($_POST['save_config'])) {
     Session::checkRight('config', UPDATE);
+    Session::checkCSRF($_POST);
     PluginRoundRobinLogger::addDebug(__FILE__ . ' - SAVE CONFIG: POST ', $_POST);
     PluginRoundRobinSettings::persistUiState();
     PluginRoundRobinSettings::saveConfig();


### PR DESCRIPTION
## Summary

  Add explicit GLPI CSRF validation before saving RoundRobin configuration changes.

  ## Why

  The configuration form already includes a GLPI CSRF token, but the save handler did not explicitly validate it before persisting
  UI state and plugin settings. This change makes the server-side save path enforce the token check before any configuration write
  occurs.

  ## Changes

  - Validate `$_POST` with `Session::checkCSRF()` before saving configuration.
  - Add an Unreleased changelog entry for the security hardening.

  ## Validation

  - Ran PHP syntax checks for all PHP files:
    - `find . -name '*.php' -print -exec php -l {} \;`