### PR TITLE
Remove GLPI core inclusion

### DIFF
--- a/front/config.form.php
+++ b/front/config.form.php
@@ -9,9 +9,6 @@
  * -------------------------------------------------------------------------
  */
 
-// GLPI 11 — include GLPI core
-include('../../../inc/includes.php');
-
 // Include plugin classes using __DIR__
 require_once __DIR__ . '/../inc/logger.class.php';
 require_once __DIR__ . '/../inc/config.class.php';


### PR DESCRIPTION
Removed inclusion of GLPI core from config.form.php to correction error:

CRITICAL: Undefined constant "GLPI_USE_CSRF_CHECK"